### PR TITLE
Fix the ocaml non-react template

### DIFF
--- a/src/templates/extensions/app/app_ml/app.ml.tmpl
+++ b/src/templates/extensions/app/app_ml/app.ml.tmpl
@@ -115,7 +115,7 @@ let main () =
       | Some inner ->
           let _ =
             Js.Global.setTimeout
-              ~f=(fun () ->
+              ~f:(fun () ->
                 let configuration_html =
                   render_configuration_html configuration
                 in


### PR DESCRIPTION
I gave `create-melange-app` a try with the ocaml syntax and the non react template and got a compile error:
```
File "src/App.ml", line 118, characters 15-16:
118 |               ~f=(fun () ->
                     ^
Error: Unbound value f
```
It looks like Reason syntax slipped into the OCaml template. This PR should fix the issue.
