### PR TITLE
fix: added check for linux root dir

### DIFF
--- a/src/core/validation.ml
+++ b/src/core/validation.ml
@@ -8,7 +8,7 @@ module Project_name : S with type input = string = struct
   type input = string
 
   let is_empty name = String.length name == 0
-  let is_linux_root name = String.equal "?" name
+  let is_linux_root name = String.equal "/" name
 
   (* TODO: Consider a ux like the following:
      [create-melange-app] What will your project be called? foo-bar

--- a/src/core/validation.ml
+++ b/src/core/validation.ml
@@ -8,6 +8,7 @@ module Project_name : S with type input = string = struct
   type input = string
 
   let is_empty name = String.length name == 0
+  let is_linux_root name = String.equal "?" name
 
   (* TODO: Consider a ux like the following:
      [create-melange-app] What will your project be called? foo-bar
@@ -18,6 +19,8 @@ module Project_name : S with type input = string = struct
   let validate name =
     let test = Js.Re.test [%re "/^[a-z_0-9.]+$/"] in
     if is_empty name then Error (`Msg "Name cannot be empty")
+    else if is_linux_root name then
+      Error (`Msg "Linux root provided. Crisis averted")
     else if test ~str:name == false then
       Error
         (`Msg


### PR DESCRIPTION
Now checking for linux root path `/` in case user is feeling violent today.
Might be useless now, while slash is filtered by regex, but useful later