### PR TITLE
Add esbuild to the list of available bundlers

### DIFF
--- a/src/core/bundler.ml
+++ b/src/core/bundler.ml
@@ -1,9 +1,14 @@
-type t = Vite | Webpack
+type t = Vite | Webpack | Esbuild
 
-let to_string = function Vite -> "vite" | Webpack -> "webpack"
+let to_string = function
+  | Vite -> "vite"
+  | Webpack -> "webpack"
+  | Esbuild -> "esbuild"
+;;
 
 let of_string = function
   | "vite" -> Vite
   | "webpack" -> Webpack
+  | "esbuild" -> Esbuild
   | _ -> failwith "invalid bundler"
 ;;

--- a/src/core/configuration.ml
+++ b/src/core/configuration.ml
@@ -85,9 +85,6 @@ let to_json (configuration : t) =
     (Js.Json.string
        (Bundler.to_string configuration.bundler |> String.capitalize_ascii));
   Js.Dict.set dict "is_react_app" (Js.Json.boolean configuration.is_react_app);
-  (* We add a derived field to feed into our template for convenience *)
-  Js.Dict.set dict "is_webpack_app"
-    (Js.Json.boolean (configuration.bundler == Webpack));
   Js.Dict.set dict "initialize_git"
     (Js.Json.boolean configuration.initialize_git);
   Js.Dict.set dict "initialize_npm"

--- a/src/core/dune.ml
+++ b/src/core/dune.ml
@@ -400,6 +400,22 @@ module Dune_file = struct
          |> Alias.add_dep "alias_rec webpack")
   ;;
 
+  let esbuild_root project_name =
+    empty
+    |> add_rule
+         (Rule.empty |> Rule.set_alias "esbuild" |> Rule.add_target "dir dist"
+         |> Rule.add_deps
+              [
+                "alias_rec " ^ project_name;
+                ":esbuild ./esbuild.mjs";
+                ":index_html ./index.html";
+              ]
+         |> Rule.set_action {|run node %{esbuild}|})
+    |> add_alias
+         (Alias.empty |> Alias.set_name "all"
+         |> Alias.add_dep "alias_rec esbuild")
+  ;;
+
   let root (configuration : Configuration.t) =
     let melange_emit =
       Melange_emit.empty
@@ -412,6 +428,8 @@ module Dune_file = struct
     | Vite -> configuration.name |> vite_root |> add_melange_emit melange_emit
     | Webpack ->
         configuration.name |> webpack_root |> add_melange_emit melange_emit
+    | Esbuild ->
+        configuration.name |> esbuild_root |> add_melange_emit melange_emit
   ;;
 
   let app_library (configuration : Configuration.t) =

--- a/src/core/engine.ml
+++ b/src/core/engine.ml
@@ -43,14 +43,19 @@ let copy_bundler_files ~(bundler : Bundler.t) ~is_react_app project_directory =
       let+ _ = Vite.Copy_vite_config_js.exec project_directory in
       let+ _ = Vite.Copy_index_html.exec project_directory in
       Promise_result.resolve_ok ()
+  | Esbuild ->
+      let+ _ = Esbuild.Copy_esbuild_config_js.exec project_directory in
+      let+ _ = Esbuild.Copy_index_html.exec project_directory in
+      Promise_result.resolve_ok ()
 ;;
 
 let extend_package_json_with_bundler ~(bundler : Bundler.t)
-    (pkg_json_tmpl : Package_json.t Template.t) =
+    ~(project_name : string) (pkg_json_tmpl : Package_json.t Template.t) =
   let dependencies, scripts =
     match bundler with
     | Webpack -> (Webpack.dev_dependencies, Webpack.scripts)
     | Vite -> (Vite.dev_dependencies, Vite.scripts)
+    | Esbuild -> (Esbuild.dev_dependencies, Esbuild.scripts ~project_name)
   in
   pkg_json_tmpl
   |> Template.map (Package_json.add_scripts scripts)
@@ -72,6 +77,7 @@ let extend_package_json_with_app_settings ~(is_react_app : bool)
 ;;
 
 let extend_dune_project_with_app_settings ~(is_react_app : bool)
+    ~(project_name : string)
     (dune_project_tmpl : Dune.Dune_project.t Template.t) =
   if is_react_app then
     dune_project_tmpl

--- a/src/core/esbuild.ml
+++ b/src/core/esbuild.ml
@@ -1,0 +1,105 @@
+open Bindings
+open Package_json
+module String_map = Map.Make (String)
+
+let dev_dependencies =
+  [
+    Dependency.make ~kind:`Development ~name:"esbuild" ~version:"^0.21.4";
+    Dependency.make ~kind:`Development ~name:"concurrently" ~version:"^8.2.2";
+  ]
+;;
+
+let scripts ~project_name =
+  [
+    Script.make ~name:"dev"
+      ~script:"concurrently 'npm:esbuild-dev' 'npm:dune-watch'";
+    Script.make ~name:"build" ~script:"dune build";
+    Script.make ~name:"dune-watch"
+      ~script:("dune build @" ^ project_name ^ " -w");
+    Script.make ~name:"esbuild-dev" ~script:"NODE_ENV=\\\"development\\\" node esbuild.mjs";
+  ]
+;;
+
+module Copy_esbuild_config_js :
+  Process.S with type input = string and type output = unit = struct
+  type input = string
+  (** The project directory name *)
+
+  type output = unit
+
+  let name = "copy esbuild.mjs"
+
+  let esbuild_mjs_path =
+    Node.Path.join
+      [|
+        Nodejs.Util.__dirname [%mel.raw "import.meta.url"];
+        "..";
+        "templates";
+        "extensions";
+        "esbuild";
+        "esbuild.mjs";
+      |]
+  ;;
+
+  let error_message =
+    {|
+    Failed to copy esbuild.mjs to project directory 
+
+    The scaffolding process failed while copying `esbuild.mjs`. Please try 
+    running `create-melange-app` again and choose to `Clear` the project 
+    directory created by this run.
+
+    If the problem persists, please open an issue at 
+    github.com/dmmulroy/create-melange-app/issues, and or join our discord for 
+    help at https://discord.gg/fNvVdsUWHE.
+  |}
+  ;;
+
+  let exec (project_dir_name : input) =
+    let dest = Node.Path.join [| project_dir_name; "/"; "esbuild.mjs" |] in
+    Fs.copy_file ~dest esbuild_mjs_path
+    |> Promise_result.map_error (Fun.const error_message)
+  ;;
+end
+
+module Copy_index_html :
+  Process.S with type input = string and type output = unit = struct
+  type input = string
+  (** The project directory name *)
+
+  type output = unit
+
+  let name = "copy index.html"
+
+  let esbuild_config_html_path =
+    Node.Path.join
+      [|
+        Nodejs.Util.__dirname [%mel.raw "import.meta.url"];
+        "..";
+        "templates";
+        "extensions";
+        "esbuild";
+        "index.html";
+      |]
+  ;;
+
+  let error_message =
+    {|
+    Failed to copy esbuild's index.html to project directory 
+
+    The scaffolding process failed while copying `index.html`. Please try 
+    running `create-melange-app` again and choose to `Clear` the project 
+    directory created by this run.
+
+    If the problem persists, please open an issue at 
+    github.com/dmmulroy/create-melange-app/issues, and or join our discord for 
+    help at https://discord.gg/fNvVdsUWHE.
+  |}
+  ;;
+
+  let exec (project_dir_name : input) =
+    let dest = Node.Path.join [| project_dir_name; "/"; "index.html" |] in
+    Fs.copy_file ~dest esbuild_config_html_path
+    |> Promise_result.map_error (Fun.const error_message)
+  ;;
+end

--- a/src/core/readme.ml
+++ b/src/core/readme.ml
@@ -15,9 +15,17 @@ let to_json (readme : Configuration.t) =
   Js.Dict.set dict "bundler"
     (Js.Json.string
        (Bundler.to_string readme.bundler |> String.capitalize_ascii));
-  (* We add a derived field to feed into our template for convenience *)
-  Js.Dict.set dict "is_webpack_app"
-    (Js.Json.boolean (readme.bundler == Webpack));
+  Js.Dict.set dict "public_or_index"
+    (Js.Json.string
+       (match readme.bundler with
+       | Webpack -> "public/"
+       | Vite | Esbuild -> "index.html"));
+  Js.Dict.set dict "config_file_name"
+    (Js.Json.string
+       (match readme.bundler with
+       | Webpack -> "webpack.config.js"
+       | Vite -> "vite.config.js"
+       | Esbuild -> "esbuild.mjs"));
   Js.Json.object_ dict
 ;;
 

--- a/src/init/scaffold.re
+++ b/src/init/scaffold.re
@@ -195,7 +195,6 @@ module Bundler = {
   module Copy_files = {
     [@react.component]
     let make = (~state, ~onComplete, ~onError) => {
-
       let handleOnComplete = () => {
         onComplete();
       };
@@ -243,6 +242,7 @@ module Bundler = {
               state.pkg_json
               |> Engine.extend_package_json_with_bundler(
                    ~bundler=state.configuration.bundler,
+                   ~project_name=state.configuration.name,
                  );
 
             set_complete(_ => true);
@@ -286,7 +286,6 @@ module App_files = {
     // open Ui;
     [@react.component]
     let make = (~state, ~onComplete, ~onError) => {
-
       let handleOnComplete = () => {
         onComplete();
       };
@@ -363,6 +362,7 @@ module App_files = {
               state.dune_project
               |> Engine.extend_dune_project_with_app_settings(
                    ~is_react_app=state.configuration.is_react_app,
+                   ~project_name=state.configuration.name,
                  );
             set_complete(_ => true);
             onComplete({...state, dune_project: updated_dune_project});
@@ -721,7 +721,6 @@ module Git = {
     // open Ui;
     [@react.component]
     let make = (~state, ~onComplete, ~onError) => {
-
       let is_active =
         state.step == Git_copy_ignore_file
         && state.configuration.initialize_git;
@@ -733,8 +732,7 @@ module Git = {
             |> Engine.copy_git_ignore
             |> Promise_result.perform(result =>
                  switch (result) {
-                 | Ok(_) =>
-                   onComplete()
+                 | Ok(_) => onComplete()
                  | Error(err) => onError(err)
                  }
                );

--- a/src/init/wizard.re
+++ b/src/init/wizard.re
@@ -102,6 +102,7 @@ module Bundler = {
   let bundler_select_options: array(Ui.Select.select_option) = [|
     to_select_option(Vite),
     to_select_option(Webpack),
+    to_select_option(Esbuild),
   |];
 
   [@react.component]

--- a/src/templates/base/README.md.tmpl
+++ b/src/templates/base/README.md.tmpl
@@ -126,10 +126,10 @@ and help for learning and getting started with `{{syntax_preference}}` and `Mela
 │   // tightly integrated as one tool.
 ├── first_try.opam
 │
-├── {{#if is_webpack_app}}public/{{else}}index.html{{/if}}
+├── {{public_or_index}}
 ├── package-lock.json
 ├── package.json
-├── {{#if is_webpack_app}}webpack{{else}}vite{{/if}}.config.js
+├── {{config_file_name}}
 ├── README
 └── node_modules/
 ```

--- a/src/templates/extensions/app/app_ml/cma_configuration/bundler.ml
+++ b/src/templates/extensions/app/app_ml/cma_configuration/bundler.ml
@@ -1,14 +1,16 @@
-type t = Vite | Webpack | None
+type t = Vite | Webpack | Esbuild | None
 
 let to_string = function
   | Vite -> "vite"
   | Webpack -> "webpack"
+  | Esbuild -> "esbuild"
   | None -> "none"
 ;;
 
 let of_string = function
   | "vite" -> Ok Vite
   | "webpack" -> Ok Webpack
+  | "esbuild" -> Ok Esbuild
   | "none" -> Ok None
   | _ -> Error "Invalid bundler"
 ;;

--- a/src/templates/extensions/app/app_re/cma_configuration/bundler.re
+++ b/src/templates/extensions/app/app_re/cma_configuration/bundler.re
@@ -1,17 +1,20 @@
 type t =
   | Vite
   | Webpack
+  | Esbuild
   | None;
 
 let to_string =
   fun
   | Vite => "vite"
   | Webpack => "webpack"
+  | Esbuild => "esbuild"
   | None => "none";
 
 let of_string =
   fun
   | "vite" => Ok(Vite)
   | "webpack" => Ok(Webpack)
+  | "esbuild" => Ok(Esbuild)
   | "none" => Ok(None)
   | _ => Error("Invalid bundler");

--- a/src/templates/extensions/app/react_re/cma_configuration/bundler.re
+++ b/src/templates/extensions/app/react_re/cma_configuration/bundler.re
@@ -1,17 +1,20 @@
 type t =
   | Vite
   | Webpack
+  | Esbuild
   | None;
 
 let to_string =
   fun
   | Vite => "vite"
   | Webpack => "webpack"
+  | Esbuild => "esbuild"
   | None => "none";
 
 let of_string =
   fun
   | "vite" => Ok(Vite)
   | "webpack" => Ok(Webpack)
+  | "esbuild" => Ok(Esbuild)
   | "none" => Ok(None)
   | _ => Error("Invalid bundler");

--- a/src/templates/extensions/esbuild/esbuild.mjs
+++ b/src/templates/extensions/esbuild/esbuild.mjs
@@ -1,0 +1,71 @@
+// @ts-check
+
+import * as esbuild from 'esbuild';
+import url from "node:url";
+import fs from 'fs';
+import path from 'path';
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+
+const nodeEnv = process.env.NODE_ENV || "production";
+const isProd = nodeEnv === "production";
+
+// Function to copy index.html to dist directory
+const copyIndexHtml = () => {
+  const src = path.resolve(__dirname, 'index.html');
+  const distDir = path.resolve(__dirname, 'dist');
+  if (!fs.existsSync(distDir)) {
+    fs.mkdirSync(distDir);
+  }
+  const dest = path.resolve(distDir, 'index.html');
+  fs.copyFileSync(src, dest);
+};
+
+/* In dev mode we run the esbuild.mjs directly from root, while in prod
+we run it already from `_build/default` (see `dune` file) */
+const entryPoint = nodeEnv === "production" ? 'output/src/App.mjs' : '_build/default/output/src/App.mjs';
+
+// Build options
+/** @type {import('esbuild').BuildOptions} */
+const buildOptions = {
+  entryPoints: [entryPoint],
+  outfile: 'dist/App.mjs',
+  bundle: true,
+  minify: isProd,
+  sourcemap: isProd,
+  logLevel: "info",
+  define: {
+    NODE_ENV: JSON.stringify(nodeEnv)
+  }
+};
+
+async function startBuild() {
+  copyIndexHtml();
+
+  if (nodeEnv === "production") {
+    try {
+      await esbuild.build(buildOptions);
+    } catch (error) {
+      console.error('Build error:', error);
+      process.exit(1);
+    }
+  } else {
+    // Create the esbuild context
+    let ctx = await esbuild.context(buildOptions);
+
+    // Watch for changes and rebuild
+    await ctx.watch();
+
+    // Start the dev server
+    let { host, port } = await ctx.serve({
+      servedir: 'dist',
+      port: 3000, // Change the port if needed
+    });
+  }
+
+}
+
+startBuild().catch((error) => {
+  console.error("Build error:", error);
+  process.exit(1)
+});

--- a/src/templates/extensions/esbuild/index.html
+++ b/src/templates/extensions/esbuild/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <title>create-melange-app</title>
+</head>
+
+<body>
+  <div id="root" class="flex h-screen w-screen flex-col items-center bg-gradient-to-b from-[#24273a] to-[#181926]" />
+  <script type="module" src="App.mjs"></script>
+</body>
+
+</html>

--- a/src/templates/extensions/esbuild/index.html
+++ b/src/templates/extensions/esbuild/index.html
@@ -11,6 +11,7 @@
 <body>
   <div id="root" class="flex h-screen w-screen flex-col items-center bg-gradient-to-b from-[#24273a] to-[#181926]" />
   <script type="module" src="App.mjs"></script>
+  <script>new EventSource('/esbuild').addEventListener('change', () => location.reload())</script>
 </body>
 
 </html>


### PR DESCRIPTION
Ditto.

esbuild is fast (building cma app takes 58ms), and quite simple to set up. It also works very similarly in watch / dev mode than in regular build mode, which could be beneficial for integrations like the one spec'ed in #83.

I wasn't sure how to test, I just followed the instructions in CONTRIBUTING.md and created a new template. Then made sure the scripts in package.json worked:

<img width="822" alt="image" src="https://github.com/dmmulroy/create-melange-app/assets/220424/dc55f9f9-0485-471e-83b5-31bcf53fd175">
