### PR TITLE
Copy `index.html` from public webpack folder to public folder of generated project

### DIFF
--- a/src/core/webpack.ml
+++ b/src/core/webpack.ml
@@ -44,6 +44,7 @@ module Copy_index_html :
         "templates";
         "extensions";
         "webpack";
+        "public";
         "index.html";
       |]
   ;;
@@ -65,7 +66,7 @@ module Copy_index_html :
   ;;
 
   let exec (project_dir_name : input) =
-    let dest = Node.Path.join [| project_dir_name; "/"; "index.html" |] in
+    let dest = Node.Path.join [| project_dir_name; "/"; "public"; "/"; "index.html" |] in
     Fs.copy_file ~dest webpack_public_dir_path
     |> Promise_result.map_error (Fun.const error_message)
   ;;


### PR DESCRIPTION
Fixes #115

Two problems are fixed here:
1️⃣ The script tried to copy the `index.html` "template" file from: `templates/extensions/webpack` folder but the correct path is `templates/extensions/webpack/public/`.
2️⃣ Webpack searches the `index.html` file in the generated projects's `public` folder but the `html` file was copied to the root. 